### PR TITLE
兼容 qBittorrent 5.2.x 的登录与添加种子响应 (#20)

### DIFF
--- a/download_to_qb.js
+++ b/download_to_qb.js
@@ -2,7 +2,7 @@
 // @name         种子下载工具
 // @namespace    https://github.com/ShaoxiongXu/M-Team-to-qBittorrent
 // @description  在【馒头】或【NexusPHP 架构】PT站种子详情页添加下载按钮，点击后可以选择【标题|种子名|副标题】并将种子添加到 qBittorrent|Transmission，支持文件重命名并指定下载位置。
-// @version      5.8
+// @version      5.9
 // @icon         https://www.qbittorrent.org/favicon.svg
 // @require      https://cdn.jsdelivr.net/npm/vue@2.7.14/dist/vue.js
 // @require      https://cdn.jsdelivr.net/gh/ShaoxiongXu/M-Team-to-qBittorrent@304e1e487cc415fa57aef27e6a1d3f74308a98e2/coco-message.js
@@ -290,7 +290,9 @@
                             reject("请检查 qBittorrent 访问地址是否正确");
                             return;
                         }
-                        if (response.responseText !== "Ok.") {
+                        // 兼容 qBittorrent 登录成功的两种响应：旧版返回 200 "Ok."；5.2.x 可能返回 204 空响应
+                        const loginOk = response.status === 204 || response.responseText === "Ok.";
+                        if (!loginOk) {
                             reject("请检查 qBittorrent 配置是否正确！");
                             return;
                         }
@@ -527,7 +529,13 @@
                         data: formData,
                         onload: function (response) {
                             const responseData = response.responseText;
-                            if (responseData !== "Ok.") {
+                            // 兼容 qBittorrent 添加成功的两种响应：旧版返回 "Ok."；5.2.x 返回 JSON {"success_count":..,"failure_count":0}
+                            let addOk = responseData === "Ok.";
+                            try {
+                                const r = JSON.parse(responseData);
+                                if (r && r.failure_count === 0) addOk = true;
+                            } catch (e) { /* 非 JSON，保持旧版判断 */ }
+                            if (!addOk) {
                                 downloadMsg();
                                 reject(`添加种子失败: ${responseData}`);
                             } else {


### PR DESCRIPTION
qBittorrent 5.2.x 改了两个接口的返回，脚本还按老的 `"Ok."` 文本判断，导致推送失败、弹「请检查 qBittorrent 配置是否正确」（#20）。

- `/api/v2/auth/login`：5.2.x 下可能返回 `204` 空 body，不再是 `"Ok."`
- `/api/v2/torrents/add`：改成返回 JSON，例如 `{"success_count":1,"failure_count":0,...}`，也不再是 `"Ok."`（其实种子已经加进去了，却被判成失败）

这里两处都加了兼容：login 接受 204 或 `"Ok."`；add 解析 JSON 看 `failure_count`，非 JSON 时回退到旧的 `"Ok."` 判断。旧版 qBittorrent 不受影响。在 5.2.2 上测过没问题。